### PR TITLE
Add Prev(x) and Middle() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ func main() {
         log.Fatalf("Error creating Lexid: %v", err)
     }
 
+    // Get the middle point (useful as first ID)
+    middle := lid.Middle()
+    fmt.Println(middle) // Output: "VVV"
+
     // Generate the next string
     firstStr := lid.Next("")
     fmt.Println(firstStr) // Output: "001"
@@ -57,13 +61,16 @@ func main() {
     secondStr := lid.Next(firstStr)
     fmt.Println(secondStr) // Output: "00b"
 
-
     // Generate a string before another
     nextBeforeStr, err := lid.NextBefore(firstStr, secondStr)
     if err != nil {
         log.Fatalf("Error generating NextBefore string: %v", err)
     }
     fmt.Println(nextBeforeStr) // Output: "003"
+
+    // Generate IDs in reverse order
+    prevStr := lid.Prev(secondStr)
+    fmt.Println(prevStr) // Output: "001"
 }
 ```
 

--- a/lexid.go
+++ b/lexid.go
@@ -323,17 +323,16 @@ func (l Lexid) prevStep(next string, step int) (prev string) {
 			}
 		}
 
-	}
-
-	// Final check for trailing zero
-	if len(nextBytes) > 0 && nextBytes[len(nextBytes)-1] == l.lower {
-		// Instead of removing blocks, we ADD a block with maximum values
-		// This ensures the result is still less than the input but doesn't end with trailing zero
-		padding := make([]byte, l.blockSize)
-		for i := range padding {
-			padding[i] = l.upper
+		// Check for trailing zero after each step and handle it
+		if len(nextBytes) > 0 && nextBytes[len(nextBytes)-1] == l.lower {
+			// Add padding with maximum values to avoid trailing zero
+			padding := make([]byte, l.blockSize)
+			for i := range padding {
+				padding[i] = l.upper
+			}
+			nextBytes = append(nextBytes, padding...)
+			// Continue with remaining steps on the padded result
 		}
-		nextBytes = append(nextBytes, padding...)
 	}
 
 	return string(nextBytes)

--- a/lexid.go
+++ b/lexid.go
@@ -117,6 +117,7 @@ func New(chars string, blockSize, stepSize int) (*Lexid, error) {
 //   - chars must contain at least 2 unique characters
 //   - blockSize must be at least 1
 //   - stepSize must be at least 1
+//   - stepSize must be less than block capacity (len(chars)^blockSize)
 type Lexid struct {
 	chars     []byte
 	nextChar  [256]byte

--- a/lexid.go
+++ b/lexid.go
@@ -58,6 +58,21 @@ func New(chars string, blockSize, stepSize int) (*Lexid, error) {
 	if len(uniqueChars) < 2 {
 		return nil, errors.New("chars must contain at least two unique characters")
 	}
+	
+	// Calculate maximum capacity for a single block
+	// This prevents stepSize from being larger than what can fit in a block
+	var maxCapacity uint64 = 1
+	for i := 0; i < blockSize; i++ {
+		if maxCapacity > (1<<64-1)/uint64(len(uniqueChars)) { // overflow check
+			maxCapacity = 1<<64 - 1
+			break
+		}
+		maxCapacity *= uint64(len(uniqueChars))
+	}
+	
+	if uint64(stepSize) >= maxCapacity {
+		return nil, fmt.Errorf("stepSize (%d) must be less than block capacity (%d)", stepSize, maxCapacity)
+	}
 
 	sort.Slice(uniqueChars, func(i, j int) bool {
 		return uniqueChars[i] < uniqueChars[j]

--- a/lexid_test.go
+++ b/lexid_test.go
@@ -134,6 +134,49 @@ func TestLexid_Prev(t *testing.T) {
 		prev = lid.Prev("000zzz")
 		assert.Equal(t, "000zzy", prev)
 	})
+
+	t.Run("prev with large step overflows bottom", func(t *testing.T) {
+		lid := Must(CharsAlphanumericLower, 3, 5)
+
+		// Going back 5 steps from "005": 005->004->003->002->001->000
+		// Since "000" ends with trailing zero, it adds padding
+		prev := lid.Prev("005")
+		assert.Equal(t, "000zzz", prev)
+		t.Logf("Prev(\"005\") = %q", prev)
+
+		// Going back 5 steps from "004": 004->003->002->001->000->add padding->continue 1 step
+		// "000" -> "000zzz" -> "000zzy" 
+		prev = lid.Prev("004")
+		assert.Equal(t, "000zzy", prev)
+		t.Logf("Prev(\"004\") = %q", prev)
+
+		// Test with longer string - should remove a block when overflowing
+		prev = lid.Prev("000005")
+		t.Logf("Prev(\"000005\") = %q", prev)
+		// 000005 going back 5 steps -> 000000, which ends with trailing zero
+		// So it adds padding: 000000zzz
+		assert.Equal(t, "000000zzz", prev)
+
+		// Test case with longer string and more steps
+		prev = lid.Prev("000004")
+		t.Logf("Prev(\"000004\") = %q", prev)
+		// 000004 going back 5 steps -> 000000 -> add padding -> continue 1 step
+		assert.Equal(t, "000000zzy", prev)
+
+		// Edge case: step=5 from minimum 3-char ID 
+		prev = lid.Prev("001")
+		t.Logf("Prev(\"001\") with step=5 = %q", prev)
+		// 001 going back 1 step -> 000 -> add padding -> continue 4 steps
+		assert.Equal(t, "000zzv", prev)
+
+		// Test with even larger step
+		lid10 := Must(CharsAlphanumericLower, 4, 10)
+		prev = lid10.Prev("0005")
+		t.Logf("Prev(\"0005\") with step=10 = %q", prev)
+		// 0005 going back 10 steps: 0005->0004->0003->0002->0001->0000->underflow
+		// Since result would be "0000" + negative offset, it underflows and adds padding
+		assert.Equal(t, "0000zzzu", prev)
+	})
 }
 
 func TestLexid_NextBefore(t *testing.T) {

--- a/lexid_test.go
+++ b/lexid_test.go
@@ -142,37 +142,31 @@ func TestLexid_Prev(t *testing.T) {
 		// Since "000" ends with trailing zero, it adds padding
 		prev := lid.Prev("005")
 		assert.Equal(t, "000zzz", prev)
-		t.Logf("Prev(\"005\") = %q", prev)
 
 		// Going back 5 steps from "004": 004->003->002->001->000->add padding->continue 1 step
-		// "000" -> "000zzz" -> "000zzy" 
+		// "000" -> "000zzz" -> "000zzy"
 		prev = lid.Prev("004")
 		assert.Equal(t, "000zzy", prev)
-		t.Logf("Prev(\"004\") = %q", prev)
 
 		// Test with longer string - should remove a block when overflowing
 		prev = lid.Prev("000005")
-		t.Logf("Prev(\"000005\") = %q", prev)
 		// 000005 going back 5 steps -> 000000, which ends with trailing zero
 		// So it adds padding: 000000zzz
 		assert.Equal(t, "000000zzz", prev)
 
 		// Test case with longer string and more steps
 		prev = lid.Prev("000004")
-		t.Logf("Prev(\"000004\") = %q", prev)
 		// 000004 going back 5 steps -> 000000 -> add padding -> continue 1 step
 		assert.Equal(t, "000000zzy", prev)
 
-		// Edge case: step=5 from minimum 3-char ID 
+		// Edge case: step=5 from minimum 3-char ID
 		prev = lid.Prev("001")
-		t.Logf("Prev(\"001\") with step=5 = %q", prev)
 		// 001 going back 1 step -> 000 -> add padding -> continue 4 steps
 		assert.Equal(t, "000zzv", prev)
 
 		// Test with even larger step
 		lid10 := Must(CharsAlphanumericLower, 4, 10)
 		prev = lid10.Prev("0005")
-		t.Logf("Prev(\"0005\") with step=10 = %q", prev)
 		// 0005 going back 10 steps: 0005->0004->0003->0002->0001->0000->underflow
 		// Since result would be "0000" + negative offset, it underflows and adds padding
 		assert.Equal(t, "0000zzzu", prev)
@@ -251,7 +245,6 @@ func TestPrevSpecificCase(t *testing.T) {
 
 	// Test the specific case: Prev("0001") should return "0000zzzz"
 	result := lid.Prev("0001")
-	t.Logf("Prev(\"0001\") = %q", result)
 	assert.Equal(t, "0000zzzz", result)
 
 	// Verify the properties
@@ -260,15 +253,12 @@ func TestPrevSpecificCase(t *testing.T) {
 
 	// Test that we can continue calling Prev
 	result2 := lid.Prev(result)
-	t.Logf("Prev(%q) = %q", result, result2)
 	assert.True(t, result2 < result, "Should be able to continue the sequence")
 
 	// Test more cases
-	t.Log("\nTesting more cases:")
 	testCases := []string{"0001", "00000001", "b000", "0010"}
 	for _, tc := range testCases {
 		prev := lid.Prev(tc)
-		t.Logf("Prev(%q) = %q", tc, prev)
 		if prev != "" {
 			assert.True(t, prev < tc, "Prev result should be less than input")
 		}


### PR DESCRIPTION
  ### Changes

  - Middle() string: Returns middle point string using the middle character of the charset
  - Prev(next string) string: Generates previous ID in reverse order
  - Added stepSize validation to prevent stepSize from exceeding block capacity

 ### Details

  - Prev(x) always returns value < x
  - When decrement would create trailing zero, adds padding with max values instead
  - Example: Prev("0001") returns "0000zzzz" (not "0000")
  - Supports custom step sizes via internal prevStep() method

 ###  Usage
```go
  lid := Must(CharsAlphanumericLower, 4, 1)

  middle := lid.Middle()        // "VVVV"
  prev := lid.Prev("0002")      // "0001" 
  prev = lid.Prev("0001")       // "0000zzzz"
  prev = lid.Prev("0000zzzz")   // "0000zzzy"
```

 ### Test Coverage

  - Full test suite for both methods
  - Edge cases: trailing zeros, underflow, invalid inputs
  - Lexicographic ordering validation

 ###  Documentation

  - Updated type documentation with invariants
  - Added method documentation and README examples
